### PR TITLE
Add require to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
+require 'csp'
 # first we need to set up a Problem
 problem = CSP::Solver::Problem.new
 # then we need to set up some variables and their domain


### PR DESCRIPTION
because: Without using a `Gemfile`, the code wasn't runnable by using the `gem install` command above alone.

this commit: Adds require to README.md so that the example is more readily executable.